### PR TITLE
Ianbranch

### DIFF
--- a/Peter Parkour Pizza/Assets/LoseMenu.unity
+++ b/Peter Parkour Pizza/Assets/LoseMenu.unity
@@ -333,6 +333,7 @@ GameObject:
   - 92: {fileID: 872010080}
   - 124: {fileID: 872010079}
   - 81: {fileID: 872010078}
+  - 114: {fileID: 872010083}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -408,6 +409,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+--- !u!114 &872010083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 872010077}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67d15d9eaa6f86c4281aecc8c416acf3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  score: {fileID: 925177444}
 --- !u!1 &899824040
 GameObject:
   m_ObjectHideFlags: 0
@@ -514,8 +527,8 @@ RectTransform:
   m_RootOrder: 1
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 47.000004, y: 50}
-  m_SizeDelta: {x: 148, y: 73}
+  m_AnchoredPosition: {x: 152.1, y: 50}
+  m_SizeDelta: {x: 358.2, y: 73}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &925177444
 MonoBehaviour:
@@ -543,7 +556,7 @@ MonoBehaviour:
     m_BestFit: 0
     m_MinSize: 4
     m_MaxSize: 300
-    m_Alignment: 4
+    m_Alignment: 3
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0

--- a/Peter Parkour Pizza/Assets/MainLevel.unity
+++ b/Peter Parkour Pizza/Assets/MainLevel.unity
@@ -437,7 +437,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 075107dbb20aa84499a676df91a27816, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  score: {fileID: 1648535146}
+  health: {fileID: 1648535146}
 --- !u!1 &398539351
 GameObject:
   m_ObjectHideFlags: 0

--- a/Peter Parkour Pizza/Assets/Scripts/DeliveryTimer.cs
+++ b/Peter Parkour Pizza/Assets/Scripts/DeliveryTimer.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 using System.Collections;
-
+using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 public class DeliveryTimer : MonoBehaviour {
@@ -17,7 +17,7 @@ public class DeliveryTimer : MonoBehaviour {
 
         if (timer <= 0)
         {
-            Application.LoadLevel("LoseMenu");
+            SceneManager.LoadScene("LoseMenu");
 
         }
 

--- a/Peter Parkour Pizza/Assets/Scripts/FinishScore.cs
+++ b/Peter Parkour Pizza/Assets/Scripts/FinishScore.cs
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+using System.Collections;
+using UnityEngine.UI;
+
+public class FinishScore : MonoBehaviour {
+
+
+    public Text score;
+	
+	// Update is called once per frame
+	void Update () {
+
+        score.text = "Score: "+Scoring.count.ToString();
+	}
+}

--- a/Peter Parkour Pizza/Assets/Scripts/FinishScore.cs.meta
+++ b/Peter Parkour Pizza/Assets/Scripts/FinishScore.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 67d15d9eaa6f86c4281aecc8c416acf3
+timeCreated: 1479032133
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Peter Parkour Pizza/Assets/Scripts/Health.cs
+++ b/Peter Parkour Pizza/Assets/Scripts/Health.cs
@@ -3,12 +3,13 @@ using System.Collections;
 
 //Adding this allows us to access members of the UI namespace including Text.
 using UnityEngine.UI;
+using UnityEngine.SceneManagement;
 
 public class Health : MonoBehaviour
 {
 
 
-    public Text score;          //Store a reference to the UI Text component which will display the number of pickups collected.
+    public Text health;          //Store a reference to the UI Text component which will display the number of pickups collected.
 
 
 
@@ -61,7 +62,7 @@ public class Health : MonoBehaviour
     void SetCountText()
     {
         //Set the text property of our our countText object to "Count: " followed by the number stored in our count variable.
-        score.text = "Health: " + count.ToString();
+        health.text = "Health: " + count.ToString();
 
 
     }
@@ -70,7 +71,7 @@ public class Health : MonoBehaviour
 
         if (count <= 0)
         {
-            Application.LoadLevel("LoseMenu");
+            SceneManager.LoadScene("LoseMenu");
 
         }
     }

--- a/Peter Parkour Pizza/Assets/Scripts/Scoring.cs
+++ b/Peter Parkour Pizza/Assets/Scripts/Scoring.cs
@@ -11,7 +11,8 @@ public class Scoring : MonoBehaviour {
 	
 
 	
-	private int count;              //Integer to store the number of pickups collected so far.
+	public static int count; 
+    //Integer to store the number of pickups collected so far.
 
 	// Use this for initialization
 	void Start()

--- a/Peter Parkour Pizza/Assets/WinMenu.unity
+++ b/Peter Parkour Pizza/Assets/WinMenu.unity
@@ -333,6 +333,7 @@ GameObject:
   - 92: {fileID: 872010080}
   - 124: {fileID: 872010079}
   - 81: {fileID: 872010078}
+  - 114: {fileID: 872010083}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -408,6 +409,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+--- !u!114 &872010083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 872010077}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67d15d9eaa6f86c4281aecc8c416acf3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  score: {fileID: 925177444}
 --- !u!1 &899824040
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Timer counts down to zero then calls lose scene
Health counts down with impacts from objects. When reaches zero calls lose scene.
Lose scene and win scene now has score from the game carried across